### PR TITLE
mark OFEP-007: Surfacing flag metadata as APPROVED

### DIFF
--- a/007-OFEP-provider-flag-metadata.md
+++ b/007-OFEP-provider-flag-metadata.md
@@ -1,6 +1,6 @@
 ## OFEP-007: Surfacing flag metadata
 
-## State: DRAFTING
+## State: APPROVED
 This proposal lays out a mechanism for flag providers to surface arbitrary flag metadata to Open Feature, and for hooks to access this metadata.
 
 


### PR DESCRIPTION
forgot to do this as part of merging the PR. I'm assuming that getting the PR approved counts as the OFEP being approved?

Signed-off-by: Pete Hodgson <github@thepete.net>