### PR TITLE
Add "static-context" paradigm OFEP

### DIFF
--- a/OFEP-single-context-paradigm.md
+++ b/OFEP-single-context-paradigm.md
@@ -1,0 +1,84 @@
+## OFEP-single-context-paradigm
+
+## State: DRAFTING
+
+This draft outlines a "single-context" paradigm - an alternative pattern and set of APIs supporting client use-cases.
+
+## Background
+
+In contrast with server-side or other service-type applications, client side apps typically operate in the context of a single user.
+Most feature flagging for these applications have been designed with this in mind.
+In summary, most client/web SDKs operate something like this:
+
+- an initialization occurs, which fetches evaluated flags in bulk for a given context (user)
+- the evaluated flags are cached in the SDK
+- flag evaluations take place against this cache, without a need to provide context (context was already used to evaluate flags in bulk)
+- Functions/methods are exposed on the SDK that signal the cache is no longer valid, and must be reconciled based on a context change. This frequently involves a network request or I/O operation.
+
+This paradigm doesn't fit well with the existing SDK, which, like most server-side SDKs, emphasizes realtime evaluation and context-per-evaluation.
+
+Though not all client side SDKs function in this way, those that do allow context per evaluation can conform to this model fairly easily.
+
+## Design
+
+To better support the "single-context" paradigm we need to define some additional handlers and add some flexibility to current APIs.
+In short, the application author now sets context globally using the existing global context mutator on the OpenFeature API object.
+This single context is used by providers for initialization and fetching evaluated flag values in bulk.
+All evaluations functions are "context-less".
+When the context is changed, providers are signalled to update their cache of evaluated flags.
+
+### Provider changes
+
+#### On-context-set handler
+
+Providers must have a mechanism to understand when their cache of evaluated flags must be invalidated or updated. An `on-context-set` handler can be defined which performs whatever operations are needed to reconcile the evaluated flags with the new context. The OpenFeature SDK calls this handler when the global context is modified.
+
+```typescript
+
+interface Provider {
+  //...
+
+  // a handler called by the SDK when context is modified
+  onContextChange?(oldContext: EvaluationContext, newContext: EvaluationContext): Promise<void>
+
+  //...
+}
+```
+
+#### Remove evaluation-context parameter on resolvers
+
+With all evaluation context represented in the global context, resolvers no longer need it as a parameter. Providers that require context at evaluation can simply access the global evaluation context for use in their evaluation.
+
+```typescript
+
+interface Provider {
+  //...
+  
+  // context parameter is removed from resolver
+  resolveBooleanEvaluation(flagKey: string, defaultValue: boolean): ResolutionDetails<boolean>;
+
+  //...
+}
+```
+
+### Client changes
+
+#### Remove evaluation-context parameter on evaluation functions
+
+Similarly to the changes in the provider, the evaluator functions on the client do not accept a context.
+
+```typescript
+interface Client {
+  //...
+
+  // context parameter is removed from evaluation API
+  getBooleanValue(flagKey: string, defaultValue: boolean, options?: FlagEvaluationOptions): boolean;
+  getBooleanDetails(flagKey: string, defaultValue: boolean, options?: FlagEvaluationOptions): EvaluationDetails<boolean>;
+
+  //...
+}
+```
+
+#### Remove context mutator
+
+The global context has a one-to-one correspondence to the providers cache of evaluated flags. It's unreasonable or impossible to reconcile multiple client-level contexts with this state. The context mutator of the client must be removed.

--- a/OFEP-single-context-paradigm.md
+++ b/OFEP-single-context-paradigm.md
@@ -7,7 +7,7 @@ This draft outlines a "single-context" paradigm - an alternative pattern and set
 ## Background
 
 In contrast with server-side or other service-type applications, client side apps typically operate in the context of a single user.
-Most feature flagging for these applications have been designed with this in mind.
+Most feature flagging SDKs for these applications have been designed with this in mind.
 In summary, most client/web SDKs operate something like this:
 
 - an initialization occurs, which fetches evaluated flags in bulk for a given context (user)

--- a/OFEP-single-context-paradigm.md
+++ b/OFEP-single-context-paradigm.md
@@ -47,21 +47,25 @@ interface Provider {
 
 While the `on-context-set` handler is executing, the cache of resolved flags may be considered "stale". `Provider authors` and `application authors` should understand the consequences of evaluating flags in this state.
 
-#### Remove evaluation-context parameter on resolvers
+#### Initialize function
 
-With all evaluation context represented in the global context, resolvers no longer need it as a parameter. Providers that require context at evaluation can simply access the global evaluation context for use in their evaluation.
+Providers may need access to the static context when they start up.
+Passing this in the provider constructor is not always possible, and ergonomics are improved by separating configuration and evaluation.
 
-```typescript
+An `initialize` function can be optionally implemented by a provider, which defines an parameter for the static context.
 
 interface Provider {
   //...
-  
-  // context parameter is removed from resolver
-  resolveBooleanEvaluation(flagKey: string, defaultValue: boolean): ResolutionDetails<boolean>;
+
+  // a function called by the SDK when the provider becomes active
+  initialize?(context: EvaluationContext): Promise<void>
 
   //...
 }
 ```
+
+> NOTE: The provider interface will retain the context parameter.
+The parameter will be supplied by the SDK from the global context.
 
 ### Client changes
 

--- a/OFEP-single-context-paradigm.md
+++ b/OFEP-single-context-paradigm.md
@@ -1,6 +1,6 @@
 ## OFEP-single-context-paradigm
 
-## State: DRAFTING
+## State: APPROVED
 
 This draft outlines a "single-context" paradigm - an alternative pattern and set of APIs supporting client use-cases.
 

--- a/OFEP-single-context-paradigm.md
+++ b/OFEP-single-context-paradigm.md
@@ -31,7 +31,7 @@ When the context is changed, providers are signalled to update their cache of ev
 
 #### On-context-set handler
 
-Providers must have a mechanism to understand when their cache of evaluated flags must be invalidated or updated. An `on-context-set` handler can be defined which performs whatever operations are needed to reconcile the evaluated flags with the new context. The OpenFeature SDK calls this handler when the global context is modified.
+Providers may need a mechanism to understand when their cache of evaluated flags must be invalidated or updated. An `on-context-set` handler can be defined which performs whatever operations are needed to reconcile the evaluated flags with the new context. The OpenFeature SDK calls this handler when the global context is modified.
 
 ```typescript
 

--- a/OFEP-single-context-paradigm.md
+++ b/OFEP-single-context-paradigm.md
@@ -39,11 +39,13 @@ interface Provider {
   //...
 
   // a handler called by the SDK when context is modified
-  onContextChange?(oldContext: EvaluationContext, newContext: EvaluationContext): Promise<void>
+  onContextSet?(oldContext: EvaluationContext, newContext: EvaluationContext): Promise<void>
 
   //...
 }
 ```
+
+While the `on-context-set` handler is executing, the cache of resolved flags may be considered "stale". `Provider authors` and `application authors` should understand the consequences of evaluating flags in this state.
 
 #### Remove evaluation-context parameter on resolvers
 
@@ -82,3 +84,22 @@ interface Client {
 #### Remove context mutator
 
 The global context has a one-to-one correspondence to the providers cache of evaluated flags. It's unreasonable or impossible to reconcile multiple client-level contexts with this state. The context mutator of the client must be removed.
+
+### Hook changes
+
+#### Remove return value from before stage
+
+Context cannot be modified at evaluation, so `before` stage 
+
+```typescript
+
+export interface Hook<T extends FlagValue = FlagValue> {
+  //...
+
+  // before handler no longer optionally returns an EvaluationContext
+  before?(hookContext: BeforeHookContext, hookHints?: HookHints): void;
+
+  //...
+}
+
+```


### PR DESCRIPTION
As discussed in the 22nd community meeting, this draft outlines a new "static-context" paradigm to better support client/web use-cases.

The key changes in this paradigm are:

- the lack a context parameter on evaluation methods
- the lack of a context setter on the client class
- a optional method in providers that is called when the global context is changed, which the provider can use to "reconcile" it's context

For more information, please see the OFEP.  

I believe this, combined with [disposal](https://github.com/open-feature/ofep/pull/30) and [events](https://github.com/open-feature/ofep/pull/25), represent the basis for proper client support in the spec.