### PR TITLE
feat: ofep for metric hooks

### DIFF
--- a/OFEP-metric-hooks.md
+++ b/OFEP-metric-hooks.md
@@ -1,0 +1,67 @@
+## OFEP-single-context-paradigm
+
+## State: PENDING REVIEW
+
+This OFEP propose to introduce OpenFeature hook for OpenTelemetry metrics.
+
+## Background
+
+We already have OpenTelemetry Span support through hooks. Similarly, we can provide a dedicated hook for 
+OpenTelemetry 
+metrics. Providing telemetry data out of the box will make OpenFeature attractive for both users and vendors. 
+
+## Proposal
+
+The proposal here is to define a set of metrics that can be used with different hook stages. For example, error metrics 
+can e collected at hook's `error` stage. Going with this background, I propose the following metrics.
+
+### evaluationRequests
+
+A counter[1] based metric to calculate the number of flag evaluation requests. This is recorded at `before` stage of 
+the hook.
+
+### evaluationSuccess
+
+A counter[1] based metric to calculate the number of successful flag evaluations. This is recorded at `after` stage of 
+the hook.
+
+### evaluationError
+
+A counter[1] based metric to calculate the number of failed flag evaluations. This is recorded at `error` stage of
+the hook.
+
+### evaluationActive
+
+An UpDownCounter[2] based metric to calculate the number of active flag evaluations currently going through 
+OpenFeature SDK. This is increased at `before` stage and decreased at `finally` stage. Given the evaluation is fast,
+the value observed here can be 0. However, when there are bottlenecks or provider slowdowns, this will be a 
+non-zero value. 
+
+### Semantic conventions 
+
+All above metrics should carry OpenTelemetry semantic convention defined attributes [3] so that any metric processor 
+can reliably process metrics produced by the hook.
+
+## Example
+
+Consider following coding example in Go. 
+
+```go
+
+    // Reader should be derived or injected 
+	var reader metric.Reader
+
+	// Derive metric hook from reader
+	metricsHook, := hooks.NewMetricsHook(reader)
+
+	// Register OpenFeature API hooks
+	openfeature.AddHooks(metricsHook)
+```
+
+### References
+
+[1] - https://opentelemetry.io/docs/specs/otel/metrics/api/#counter
+
+[2] - https://opentelemetry.io/docs/specs/otel/metrics/api/#updowncounter
+
+[3] - https://opentelemetry.io/docs/specs/otel/logs/semantic_conventions/feature-flags/ 

--- a/OFEP-metric-hooks.md
+++ b/OFEP-metric-hooks.md
@@ -6,12 +6,12 @@ This OFEP propose to introduce OpenFeature hook for OpenTelemetry metrics.
 
 ## Background
 
-We already have OpenTelemetry Span support through hooks. Similarly, we can provide a dedicated hook for OpenTelemetry 
-metrics. Providing telemetry data out of the box will make OpenFeature attractive for both users and vendors. 
+We already have OpenTelemetry Span support through hooks. Similarly, we can provide a dedicated hook for OpenTelemetry
+metrics. Providing telemetry data out of the box will make OpenFeature attractive for both users and vendors.
 
 ## Proposal
 
-The proposal here is to define a set of metrics that can be used with different hook stages. For example, error metrics 
+The proposal here is to define a set of metrics that can be used with different hook stages. For example, error metrics
 can be collected at the hook's `error` stage. Going with this background, I propose the following metrics.
 
 ## Metrics
@@ -20,26 +20,26 @@ All metrics defined through this proposal carry OpenTelemetry semantic conventio
 
 - feature_flag.key: The unique identifier of the feature flag
 - feature_flag.provider_name: The name of the service provider that performs the flag evaluation
-- feature_flag.variant:	SHOULD be a semantic identifier for a value. If one is unavailable, a stringified version of 
+- feature_flag.variant:    SHOULD be a semantic identifier for a value. If one is unavailable, a stringified version of
   the value can be used
 
 Given below is the list of metrics proposed and their usage,
 
 ### feature_flag.evaluation_requests
 
-A counter[2] based metric to calculate the number of flag evaluation requests. This is recorded at `before` stage of 
+A counter[2] based metric to calculate the number of flag evaluation requests. This is recorded at `before` stage of
 the hook.
 
 This metric is useful to understand flag evaluation requests received through OpenFeature SDK.
 
 ### feature_flag.evaluation_success
 
-A counter[2] based metric to calculate the number of successful flag evaluations. This is recorded at `after` stage of 
+A counter[2] based metric to calculate the number of successful flag evaluations. This is recorded at `after` stage of
 the hook.
 
 This metric is useful to understand successful flag evaluations. This metric contain following extra dimension(s),
 
-- reason : evaluation reason extracted from flag resolution details[3] 
+- reason : evaluation reason extracted from flag resolution details[3]
 
 ### feature_flag.evaluation_error
 
@@ -52,26 +52,26 @@ This metric is useful to understand flag evaluation errors. This metric contain 
 
 ### feature_flag.evaluation_active
 
-An UpDownCounter[4] based metric to calculate the number of active flag evaluations currently going through 
+An UpDownCounter[4] based metric to calculate the number of active flag evaluations currently going through
 OpenFeature SDK. This is increased at `before` stage and decreased at `finally` stage.
 
 Given the evaluation is fast, the value observed here can be 0. However, when there are bottlenecks or provider
-slowdowns, this will be a non-zero value. 
+slowdowns, this will be a non-zero value.
 
 ## Example
 
-Consider following coding example in Go. 
+Consider following coding example in Go.
 
 ```go
 
-        // Reader should be derived or injected 
-	var reader metric.Reader
+// Reader should be derived or injected 
+var reader metric.Reader
 
-	// Derive metric hook from reader
-	metricsHook := hooks.NewMetricsHook(reader)
+// Derive metric hook from reader
+metricsHook := hooks.NewMetricsHook(reader)
 
-	// Register OpenFeature API hooks
-	openfeature.AddHooks(metricsHook)
+// Register OpenFeature API hooks
+openfeature.AddHooks(metricsHook)
 ```
 
 ### References

--- a/OFEP-metric-hooks.md
+++ b/OFEP-metric-hooks.md
@@ -37,7 +37,7 @@ This metric is useful to understand flag evaluation requests received through Op
 A counter[2] based metric to calculate the number of successful flag evaluations. This is recorded at `after` stage of
 the hook.
 
-This metric is useful to understand successful flag evaluations. This metric contain following extra dimension(s),
+This metric is useful for understanding successful flag evaluations. This metric contains the following extra dimension(s),
 
 - reason : evaluation reason extracted from flag resolution details[3]
 

--- a/OFEP-metric-hooks.md
+++ b/OFEP-metric-hooks.md
@@ -43,7 +43,7 @@ This metric is useful for understanding successful flag evaluations. This metric
 
 ### feature_flag.evaluation_error_total
 
-A counter[2] based metric to calculate the number of failed flag evaluations. This is recorded at `error` stage of
+A counter[2] based metric to calculate the number of failed flag evaluations. This is recorded at the `error` stage of
 the hook.
 
 This metric is useful to understand flag evaluation errors. This metric contain following extra dimension(s),

--- a/OFEP-metric-hooks.md
+++ b/OFEP-metric-hooks.md
@@ -1,6 +1,6 @@
 ## OFEP-hook-for-metrics
 
-## State: PENDING REVIEW
+## State: APPROVED
 
 This OFEP proposes to introduce an OpenFeature hook for OpenTelemetry metrics.
 

--- a/OFEP-metric-hooks.md
+++ b/OFEP-metric-hooks.md
@@ -2,7 +2,7 @@
 
 ## State: PENDING REVIEW
 
-This OFEP propose to introduce OpenFeature hook for OpenTelemetry metrics.
+This OFEP proposes to introduce an OpenFeature hook for OpenTelemetry metrics.
 
 ## Background
 

--- a/OFEP-metric-hooks.md
+++ b/OFEP-metric-hooks.md
@@ -46,7 +46,7 @@ This metric is useful for understanding successful flag evaluations. This metric
 A counter[2] based metric to calculate the number of failed flag evaluations. This is recorded at the `error` stage of
 the hook.
 
-This metric is useful to understand flag evaluation errors. This metric contain following extra dimension(s),
+This metric is useful for understanding flag evaluation errors. This metric contains the following extra dimension(s),
 
 - exception : error/exception message extracted from the evaluation error
 

--- a/OFEP-metric-hooks.md
+++ b/OFEP-metric-hooks.md
@@ -39,7 +39,7 @@ non-zero value.
 
 ### Semantic conventions 
 
-All above metrics should carry OpenTelemetry semantic convention defined attributes [3] so that any metric processor 
+All above metrics should carry OpenTelemetry semantic conventions defined attributes [3] so that any metric processor 
 can reliably process metrics produced by the hook.
 
 ## Example

--- a/OFEP-metric-hooks.md
+++ b/OFEP-metric-hooks.md
@@ -52,7 +52,7 @@ Consider following coding example in Go.
 	var reader metric.Reader
 
 	// Derive metric hook from reader
-	metricsHook, := hooks.NewMetricsHook(reader)
+	metricsHook := hooks.NewMetricsHook(reader)
 
 	// Register OpenFeature API hooks
 	openfeature.AddHooks(metricsHook)

--- a/OFEP-metric-hooks.md
+++ b/OFEP-metric-hooks.md
@@ -25,14 +25,14 @@ All metrics defined through this proposal carry OpenTelemetry semantic conventio
 
 Given below is the list of metrics proposed and their usage,
 
-### feature_flag.evaluation_requests
+### feature_flag.evaluation_request_total
 
 A counter[2] based metric to calculate the number of flag evaluation requests. This is recorded at `before` stage of
 the hook.
 
 This metric is useful to understand flag evaluation requests received through OpenFeature SDK.
 
-### feature_flag.evaluation_success
+### feature_flag.evaluation_success_total
 
 A counter[2] based metric to calculate the number of successful flag evaluations. This is recorded at `after` stage of
 the hook.
@@ -41,7 +41,7 @@ This metric is useful to understand successful flag evaluations. This metric con
 
 - reason : evaluation reason extracted from flag resolution details[3]
 
-### feature_flag.evaluation_error
+### feature_flag.evaluation_error_total
 
 A counter[2] based metric to calculate the number of failed flag evaluations. This is recorded at `error` stage of
 the hook.
@@ -50,7 +50,7 @@ This metric is useful to understand flag evaluation errors. This metric contain 
 
 - exception : error/exception message extracted from the evaluation error
 
-### feature_flag.evaluation_active
+### feature_flag.evaluation_active_count
 
 An UpDownCounter[4] based metric to calculate the number of active flag evaluations currently going through
 OpenFeature SDK. This is increased at `before` stage and decreased at `finally` stage.

--- a/OFEP-metric-hooks.md
+++ b/OFEP-metric-hooks.md
@@ -58,9 +58,34 @@ OpenFeature SDK. This is increased at `before` stage and decreased at `finally` 
 Given the evaluation is fast, the value observed here can be 0. However, when there are bottlenecks or provider
 slowdowns, this will be a non-zero value.
 
+## Expansion options
+
+Given below are future expansions that can be build on top of the metrics hook. These options will not be
+implemented as they require further discussions and agreements from the community.
+
+### Metric to measure latency
+
+credits - Justin Abrahms
+
+Flag evaluation latency can be calculated with time measurements between `finally` and `before` stages. However,
+this requires time measurement to be shared between two stages, which require either a context propagation or a shared
+variable (potentially a map). Alternatively, SDK could mark the evaluation start timestamp to enhance the accuracy
+of the measurement
+
+### Scope dimension
+
+credits - Michael Beemer
+
+It is possible to add an additional dimension representing the configuration of the feature flag being evaluated. A
+feature flag usually has a scope such as a project, workspace, namespace, or application. This can be further
+expanded to environment-specific configurations such as dev, hardening, and production or the cloud provider such as
+AWS, Azure or GCP. Adding this dimension through an agreed attribute name (suggested name - `scope`) benefits metric
+evaluations (ex:- drill down to cloud provider specific flag evaluations)
+
+
 ## Example
 
-Consider following coding example in Go.
+Consider following coding example in Go for usage of the hook.
 
 ```go
 
@@ -73,6 +98,8 @@ metricsHook := hooks.NewMetricsHook(reader)
 // Register OpenFeature API hooks
 openfeature.AddHooks(metricsHook)
 ```
+
+Injected `metric.Reader` will perform the metric export and API is simple enough for developers.
 
 ### References
 

--- a/OFEP-metric-hooks.md
+++ b/OFEP-metric-hooks.md
@@ -1,4 +1,4 @@
-## OFEP-single-context-paradigm
+## OFEP-hook-for-metrics
 
 ## State: PENDING REVIEW
 

--- a/OFEP-metric-hooks.md
+++ b/OFEP-metric-hooks.md
@@ -20,7 +20,7 @@ All metrics defined through this proposal carry OpenTelemetry semantic conventio
 
 - feature_flag.key: The unique identifier of the feature flag
 - feature_flag.provider_name: The name of the service provider that performs the flag evaluation
-- feature_flag.variant:    SHOULD be a semantic identifier for a value. If one is unavailable, a stringified version of
+- feature_flag.variant: SHOULD be a semantic identifier for a value. If one is unavailable, a stringified version of
   the value can be used
 
 Given below is the list of metrics proposed and their usage,

--- a/OFEP-metric-hooks.md
+++ b/OFEP-metric-hooks.md
@@ -48,7 +48,7 @@ Consider following coding example in Go.
 
 ```go
 
-    // Reader should be derived or injected 
+        // Reader should be derived or injected 
 	var reader metric.Reader
 
 	// Derive metric hook from reader

--- a/OFEP-metric-hooks.md
+++ b/OFEP-metric-hooks.md
@@ -7,7 +7,7 @@ This OFEP proposes to introduce an OpenFeature hook for OpenTelemetry metrics.
 ## Background
 
 We already have OpenTelemetry Span support through hooks. Similarly, we can provide a dedicated hook for OpenTelemetry
-metrics. Providing telemetry data out of the box will make OpenFeature attractive for both users and vendors.
+metrics. Providing an easy method to collect standardized telemetry data will make OpenFeature attractive for both users and vendors.
 
 ## Proposal
 

--- a/OFEP-metric-hooks.md
+++ b/OFEP-metric-hooks.md
@@ -6,8 +6,7 @@ This OFEP propose to introduce OpenFeature hook for OpenTelemetry metrics.
 
 ## Background
 
-We already have OpenTelemetry Span support through hooks. Similarly, we can provide a dedicated hook for 
-OpenTelemetry 
+We already have OpenTelemetry Span support through hooks. Similarly, we can provide a dedicated hook for OpenTelemetry 
 metrics. Providing telemetry data out of the box will make OpenFeature attractive for both users and vendors. 
 
 ## Proposal
@@ -15,32 +14,49 @@ metrics. Providing telemetry data out of the box will make OpenFeature attractiv
 The proposal here is to define a set of metrics that can be used with different hook stages. For example, error metrics 
 can be collected at the hook's `error` stage. Going with this background, I propose the following metrics.
 
-### evaluationRequests
+## Metrics
 
-A counter[1] based metric to calculate the number of flag evaluation requests. This is recorded at `before` stage of 
+All metrics defined through this proposal carry OpenTelemetry semantic conventions defined attributes(dimensions)[1].
+
+- feature_flag.key: The unique identifier of the feature flag
+- feature_flag.provider_name: The name of the service provider that performs the flag evaluation
+- feature_flag.variant:	SHOULD be a semantic identifier for a value. If one is unavailable, a stringified version of 
+  the value can be used
+
+Given below is the list of metrics proposed and their usage,
+
+### feature_flag.evaluation_requests
+
+A counter[2] based metric to calculate the number of flag evaluation requests. This is recorded at `before` stage of 
 the hook.
 
-### evaluationSuccess
+This metric is useful to understand flag evaluation requests received through OpenFeature SDK.
 
-A counter[1] based metric to calculate the number of successful flag evaluations. This is recorded at `after` stage of 
+### feature_flag.evaluation_success
+
+A counter[2] based metric to calculate the number of successful flag evaluations. This is recorded at `after` stage of 
 the hook.
 
-### evaluationError
+This metric is useful to understand successful flag evaluations. This metric contain following extra dimension(s),
 
-A counter[1] based metric to calculate the number of failed flag evaluations. This is recorded at `error` stage of
+- reason : evaluation reason extracted from flag resolution details[3] 
+
+### feature_flag.evaluation_error
+
+A counter[2] based metric to calculate the number of failed flag evaluations. This is recorded at `error` stage of
 the hook.
 
-### evaluationActive
+This metric is useful to understand flag evaluation errors. This metric contain following extra dimension(s),
 
-An UpDownCounter[2] based metric to calculate the number of active flag evaluations currently going through 
-OpenFeature SDK. This is increased at `before` stage and decreased at `finally` stage. Given the evaluation is fast,
-the value observed here can be 0. However, when there are bottlenecks or provider slowdowns, this will be a 
-non-zero value. 
+- exception : error/exception message extracted from the evaluation error
 
-### Semantic conventions 
+### feature_flag.evaluation_active
 
-All above metrics should carry OpenTelemetry semantic conventions defined attributes [3] so that any metric processor 
-can reliably process metrics produced by the hook.
+An UpDownCounter[4] based metric to calculate the number of active flag evaluations currently going through 
+OpenFeature SDK. This is increased at `before` stage and decreased at `finally` stage.
+
+Given the evaluation is fast, the value observed here can be 0. However, when there are bottlenecks or provider
+slowdowns, this will be a non-zero value. 
 
 ## Example
 
@@ -60,8 +76,10 @@ Consider following coding example in Go.
 
 ### References
 
-[1] - https://opentelemetry.io/docs/specs/otel/metrics/api/#counter
+[1] - https://opentelemetry.io/docs/specs/otel/logs/semantic_conventions/feature-flags/
 
-[2] - https://opentelemetry.io/docs/specs/otel/metrics/api/#updowncounter
+[2] - https://opentelemetry.io/docs/specs/otel/metrics/api/#counter
 
-[3] - https://opentelemetry.io/docs/specs/otel/logs/semantic_conventions/feature-flags/ 
+[3] - https://openfeature.dev/specification/types#resolution-details
+
+[4] - https://opentelemetry.io/docs/specs/otel/metrics/api/#updowncounter

--- a/OFEP-metric-hooks.md
+++ b/OFEP-metric-hooks.md
@@ -58,6 +58,33 @@ OpenFeature SDK. This is increased at `before` stage and decreased at `finally` 
 Given the evaluation is fast, the value observed here can be 0. However, when there are bottlenecks or provider
 slowdowns, this will be a non-zero value.
 
+## Extra dimensions
+
+If needed, extra dimensions can be added to any of the above metrics. To provide this flexibility, language specific
+implementations should support constructor options to the hook. For example, in Go, this can look like below,
+
+```go
+NewMetricsHook(reader,
+    WithFlagMetadataDimensions(
+        DimensionDescription{
+            Key:  "scope",
+            Type: String,
+        }))
+```
+
+Given below are proposed extra dimensions.
+
+### Scope (mapped from flag metadata)
+
+credits - Michael Beemer
+
+It is possible to add an additional dimension representing the configuration of the feature flag being evaluated. A
+feature flag usually has a scope such as a project, workspace, namespace, or application. This can be further
+expanded to environment-specific configurations such as dev, hardening, and production or the cloud provider such as
+AWS, Azure or GCP. Adding this dimension through an agreed attribute name (suggested name - `scope`) benefits metric
+evaluations (ex:- drill down to cloud provider specific flag evaluations).
+
+
 ## Expansion options
 
 Below are future expansions that can be built on top of the metrics hook. These options will not be
@@ -72,18 +99,13 @@ this requires time measurement to be shared between two stages, which require ei
 variable (potentially a map). Alternatively, SDK could mark the evaluation start timestamp to enhance the accuracy
 of the measurement
 
-### Scope dimension
+## Implementation considerations
 
-credits - Michael Beemer
+Most of the OpenFeature SDKs already have support for Span hooks. The metrics hook proposed through this OFEP should be 
+implemented into the same package to reduce release and maintenance efforts. However, if there is a significant 
+impact (ex:- dependency size for example in java jar), then the implementation may be done in a dedicated package.
 
-It is possible to add an additional dimension representing the configuration of the feature flag being evaluated. A
-feature flag usually has a scope such as a project, workspace, namespace, or application. This can be further
-expanded to environment-specific configurations such as dev, hardening, and production or the cloud provider such as
-AWS, Azure or GCP. Adding this dimension through an agreed attribute name (suggested name - `scope`) benefits metric
-evaluations (ex:- drill down to cloud provider specific flag evaluations)
-
-
-## Example
+## Code Example
 
 Consider following coding example in Go for usage of the hook.
 

--- a/OFEP-metric-hooks.md
+++ b/OFEP-metric-hooks.md
@@ -60,7 +60,7 @@ slowdowns, this will be a non-zero value.
 
 ## Expansion options
 
-Given below are future expansions that can be build on top of the metrics hook. These options will not be
+Below are future expansions that can be built on top of the metrics hook. These options will not be
 implemented as they require further discussions and agreements from the community.
 
 ### Metric to measure latency

--- a/OFEP-metric-hooks.md
+++ b/OFEP-metric-hooks.md
@@ -13,7 +13,7 @@ metrics. Providing telemetry data out of the box will make OpenFeature attractiv
 ## Proposal
 
 The proposal here is to define a set of metrics that can be used with different hook stages. For example, error metrics 
-can e collected at hook's `error` stage. Going with this background, I propose the following metrics.
+can be collected at the hook's `error` stage. Going with this background, I propose the following metrics.
 
 ### evaluationRequests
 


### PR DESCRIPTION
## This PR

Introduce an enhancement proposal to introduce OpenTelemetry metric hooks. 

Consider checking PR [1] for a POC implementation in Go sdk. 

Besides, see below Prometheus samples for metrics,

**feature_flag.evaluation_requests_total**
<img width="2542" alt="image" src="https://github.com/open-feature/ofep/assets/8186721/6e60ed08-a6a2-4ed5-a565-5945205e9a47">

**feature_flag.evaluation_success_total**
<img width="2542" alt="image" src="https://github.com/open-feature/ofep/assets/8186721/e5877b13-ebd3-4159-b3d0-eb993374df26">

**feature_flag.evaluation_error_total**
<img width="2542" alt="image" src="https://github.com/open-feature/ofep/assets/8186721/83d6dc70-23a3-470a-86b3-91b4f5d03d7a">

**feature_flag.evaluation_requests_total**
<img width="2542" alt="image" src="https://github.com/open-feature/ofep/assets/8186721/132089e9-768c-4a33-bf40-5c456c65784b">



[1] - https://github.com/open-feature/go-sdk-contrib/pull/217